### PR TITLE
[Pinion] bootstrap: Pinionize template files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+See `.platform/pinion/AGENTS.md` in the workspace drop-in.

--- a/sprint-1.md
+++ b/sprint-1.md
@@ -1,0 +1,4 @@
+# Sprint 1
+
+## Sprint Goal
+Ship a modernized, test-backed Node.js web service that follows current runtime and container best practices. (Example sprint only. Update as needed.)


### PR DESCRIPTION
Files from the Pinionize packaged `bootstrap_files/` template were copied into the linked repository (shadow `user-repo/`), then pushed on this branch. No LLM step.